### PR TITLE
fix(ios): update health settings for iOS and bump version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.1
+* Fix health settings for ios.
+
 ## 0.3.0
 * Add wallpaper option to ios.
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -187,6 +187,11 @@ class MyApp extends StatelessWidget {
           title: const Text("Wallpaper settings"),
           trailing: const Icon(Icons.chevron_right),
         ),
+        ListTile(
+          onTap: settings.healthKit,
+          title: const Text("Open health kit"),
+          trailing: const Icon(Icons.chevron_right),
+        ),
       ],
     );
   }

--- a/lib/core/open_settings_plus_ios.dart
+++ b/lib/core/open_settings_plus_ios.dart
@@ -110,7 +110,7 @@ class OpenSettingsPlusIOS extends OpenSettingsPlus {
   /// Open iOS settings in HealthKit section.
   /// returns operation successful or failure.
   Future<bool> healthKit() {
-    return sendCustomMessage('App-Prefs:HealthKit');
+    return sendCustomMessage('App-prefs:HEALTH&path=SOURCES');
   }
 
   /// Open iOS settings in iCloud section.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: open_settings_plus
 description: The most complete flutter plugin packages for open various settings screen, covering newer versions of ios and android.
-version: 0.3.0
+version: 0.3.1
 homepage: https://github.com/yanncabral/open_settings_plus
 
 environment:


### PR DESCRIPTION
Title: Fix HealthKit setting issue for iOS and Upgrade to Version 0.3.1 

Hello, 

This Pull Request contains a few changes:

1. I've fixed the problematic health settings for iOS in the HealthKit section. The previous message sent by 'healthKit' function was not opening the appropriate iOS setting. I have now updated it to send 'App-prefs:HEALTH&path=SOURCES' which successfully opens up the correct setting screen.

2. I've added a new tile in our main.dart file by implementing ListTile widget to open the health kit setting when tapped. 

3. The version of the package in the pubsec.yaml file has been upgraded from 0.3.0 to 0.3.1 to reflect these changes.

4. These changes have also been reflected in the CHANGELOG.md file for end user visibility.

I kindly request you to review these changes and provide your approval or feedback.

Thank you.