### PR TITLE
(fix android): Remove android ndk declaration in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,8 +34,6 @@ android {
         testNamespace "br.com.yanncabral.open_settings_plus"
     }
     compileSdkVersion 34
-    ndkVersion "25.1.8937393"
-
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17


### PR DESCRIPTION
Hello, 

This PR removes the NDK declaration in Android build.gradle file.

The NDK should not be needed since there is no C/C++ dependencies involved in this package.

This should remove a warning when compiling an Android app without ndk declaration:
```
One or more plugins require a higher Android NDK version.
Fix this issue by adding the following to /your_project/android/app/build.gradle:
android {
  ndkVersion "25.1.8937393"
  ...
}
```

Please let me know if further changes are needed.
Thank you 