### PR TITLE
fix: namespace and testNamespace must have different names

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ android {
     }
 // Conditional for compatibility with AGP <4.2.
     if (project.android.hasProperty("testNamespace")) {
-        testNamespace "br.com.yanncabral.open_settings_plus"
+        testNamespace "br.com.yanncabral.open_settings_plus.test"
     }
     compileSdkVersion 34
 


### PR DESCRIPTION
# Description

Fix issue #19: `namespace` and `testNamespace` in `build.gradle` config must have different names.

This problem causes a warning when running the android app, and an error when trying to run tests on the Android code (for those using flutter add-to-app - see below).

![image](https://github.com/user-attachments/assets/2dd85689-2122-43c2-b46d-f778b0f4e1cb)

@yanncabral Can you merge and publish this fix please? Your lib is awesome, but I am blocked right now because it breaks our CI for native Android tests