### PR TITLE
fix: add version field to example app pubspec.yaml

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,6 +3,8 @@ description: Demonstrates how to use the open_settings_plus plugin.
 
 publish_to: "none"
 
+version: 1.0.0+1
+
 environment:
   sdk: ">=3.1.0"
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Fixed the App Store submission warning by adding a version field to the example app's `pubspec.yaml` file.

The warning was: "Action Required: You must set a build name and number in the pubspec.yaml file version field before submitting to the App Store."

**Changes made:**
- Added `version: 1.0.0+1` to `example/pubspec.yaml`
  - `1.0.0` is the version name (build name)
  - `+1` is the build number
- This follows Flutter's standard versioning format for apps

This resolves the App Store submission requirement and ensures the example app can be properly built and submitted if needed.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore