### PR TITLE
Use setup-dart for pub.dev publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,10 @@ jobs:
           flutter build ios --no-codesign --verbose
         working-directory: example
 
+      - name: 🎯 Setup Dart for pub.dev publishing
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: dart-lang/setup-dart@v1
+
       - name: 🚀 Publish
         if: startsWith(github.ref, 'refs/tags/v')
         run: dart pub publish --force


### PR DESCRIPTION
## Summary

- Add `dart-lang/setup-dart@v1` before the tag publish step.
- This lets `dart pub publish` use GitHub OIDC / pub.dev automated publishing instead of falling back to interactive Google OAuth in CI.

## Context

The `v0.5.0` tag workflow reached the `🚀 Publish` step but got stuck waiting for browser authorization:

```text
Pub needs your authorization to upload packages on your behalf.
Waiting for your authorization...
```

## Validation

- Parsed `.github/workflows/publish.yml` as YAML.

## Follow-up required

After this merges, configure automated publishing for `open_settings_plus` on pub.dev if it is not already enabled, then move/recreate the `v0.5.0` tag to the merge commit to rerun the publish workflow.
